### PR TITLE
Enable fusioncloud&terraform job

### DIFF
--- a/config/zuul/openlab-main.yaml
+++ b/config/zuul/openlab-main.yaml
@@ -39,7 +39,7 @@
           - cloudfoundry-incubator/bosh-huaweicloud-cpi-release:
               exclude-unprotected-branches: true
           - terraform-providers/terraform-provider-huaweicloud:
-              exclude-unprotected-branches: true
+              exclude-unprotected-branches: false
           - kubernetes-sigs/cluster-api-provider-openstack:
               exclude-unprotected-branches: true
           - docker/machine:


### PR DESCRIPTION
Master branch of terraform-providers/terraform-provider-huaweicloud
is unprotected, so don't set exclude-unprotected-branches
for it.