### PR TITLE
Min disk is 40G in Huaweicloud

### DIFF
--- a/etc/nodepool/openlab-nodepool.yaml.j2
+++ b/etc/nodepool/openlab-nodepool.yaml.j2
@@ -258,10 +258,10 @@ providers:
             volume-size: 100
           - name: ubuntu-xenial-ut
             diskimage: ubuntu-xenial
-            # 1C-2G-20G
+            # 1C-2G-40G
             flavor-name: 's3.medium.2'
             boot-from-volume: True
-            volume-size: 20
+            volume-size: 40
           - name: ubuntu-xenial-huaweicloud
             diskimage: ubuntu-xenial
             # 4C-8G-100G


### PR DESCRIPTION
Update boot from volume size to 40G to march min disk of image
in Huawei cloud.

Related-Bug: theopenlab/openlab#214